### PR TITLE
fixing issue 16

### DIFF
--- a/crates/brush-app/app/src/main/java/com/splats/app/MainActivity.java
+++ b/crates/brush-app/app/src/main/java/com/splats/app/MainActivity.java
@@ -236,6 +236,9 @@ public class MainActivity extends GameActivity {
                 Uri uri = data.getData();
                 if (uri != null) {
                     selectedVideoFile = ensureLocalFileForUri(uri, "telemetry_video_", ".mp4");
+                    if (selectedVideoFile != null) {
+                        notifyPlatformEvent("mp4_picked", selectedVideoFile.getAbsolutePath());
+                    }
                     VideoFrameExtractor.extractFrames(this, uri, new VideoFrameExtractor.ExtractionCallback() {
                         @Override
                         public void onFinished() {
@@ -249,11 +252,13 @@ public class MainActivity extends GameActivity {
                             Log.e(TAG, "Frame extraction failed", e);
                             Toast.makeText(MainActivity.this, "Extraction failed: " + e.getMessage(),
                                     Toast.LENGTH_SHORT).show();
+                            notifyPlatformEvent("extraction_failed", "");
                         }
                     });
                 }
             } else {
                 Toast.makeText(this, "No video selected", Toast.LENGTH_SHORT).show();
+                notifyPlatformEvent("extraction_failed", "");
             }
             // Do NOT call FilePicker.onPicked — this never goes through Rust
             super.onActivityResult(requestCode, resultCode, data);
@@ -294,9 +299,14 @@ public class MainActivity extends GameActivity {
     }
 
     private void startTelemetryPreprocessIfReady() {
-        if (telemetryRunning) return;
-        if (selectedCsvFile == null || selectedVideoFile == null) return;
-        if (!selectedCsvFile.exists() || !selectedVideoFile.exists()) return;
+        if (telemetryRunning) {
+            notifyPlatformEvent("telemetry_failed", "Already running");
+            return;
+        }
+        if (selectedCsvFile == null || selectedVideoFile == null || !selectedCsvFile.exists() || !selectedVideoFile.exists()) {
+            notifyPlatformEvent("telemetry_failed", "Missing required files");
+            return;
+        }
 
         cleanupTelemetryOutputs();
         telemetryRunning = true;
@@ -345,6 +355,7 @@ public class MainActivity extends GameActivity {
                     String msg = error.getMessage() != null ? error.getMessage() : "Telemetry preprocess failed";
                     Toast.makeText(MainActivity.this, "Telemetry preprocess failed", Toast.LENGTH_LONG).show();
                     Toast.makeText(MainActivity.this, msg, Toast.LENGTH_LONG).show();
+                    notifyPlatformEvent("telemetry_failed", "");
                 }
             }
         };

--- a/crates/brush-ui/src/scene.rs
+++ b/crates/brush-ui/src/scene.rs
@@ -140,28 +140,40 @@ impl ScenePanel {
         let purple = Color32::from_rgb(120, 80, 160);
         let mut load_option = None;
 
-        let button = |label: &str, color: Color32| {
+        let is_busy = self.is_extracting || self.telemetry_running;
+
+        let button = |label: &str, color: Color32, enabled: bool| {
+            let fill_color = if enabled {
+                color
+            } else {
+                Color32::from_rgba_premultiplied(
+                    (color.r() as f32 * 0.5) as u8,
+                    (color.g() as f32 * 0.5) as u8,
+                    (color.b() as f32 * 0.5) as u8,
+                    128,
+                )
+            };
             Button::new(RichText::new(label).size(13.0))
                 .min_size(egui::vec2(button_width, button_height))
-                .fill(color)
+                .fill(fill_color)
                 .stroke(egui::Stroke::NONE)
         };
 
         // Row 1: Data selection
         ui.horizontal(|ui| {
-            if ui.add(button("📁 File", blue)).clicked() {
+            if ui.add_enabled(!is_busy, button("📁 File", blue, !is_busy)).clicked() {
                 load_option = Some(DataSource::PickFile);
             }
             let mp4_label = self.selected_mp4.as_ref()
                 .map(|s| format!("🎬 {}", s))
                 .unwrap_or_else(|| "🎬 Choose MP4".to_string());
-            if ui.add(button(&mp4_label, blue)).clicked() {
+            if ui.add_enabled(!is_busy, button(&mp4_label, blue, !is_busy)).clicked() {
                 process.call_platform_action("choose_mp4");
             }
             let csv_label = self.selected_csv.as_ref()
                 .map(|s| format!("📄 {}", s))
                 .unwrap_or_else(|| "📄 Choose CSV".to_string());
-            if ui.add(button(&csv_label, green)).clicked() {
+            if ui.add_enabled(!is_busy, button(&csv_label, green, !is_busy)).clicked() {
                 process.call_platform_action("choose_csv");
             }
         });
@@ -171,12 +183,14 @@ impl ScenePanel {
         // Row 2: Pipeline execution
         ui.horizontal(|ui| {
             let extract_label = if self.is_extracting { "🖼 Extracting..." } else { "🖼 Extract" };
-            if ui.add(button(extract_label, blue)).clicked() {
+            if ui.add_enabled(!is_busy, button(extract_label, blue, !is_busy)).clicked() {
                 process.call_platform_action("extract_frames");
+                self.is_extracting = true;
             }
 
             let train_label = if self.telemetry_running { "🚂 Training..." } else { "🚂 Train" };
-            if ui.add(button(train_label, purple)).clicked() {
+            let train_enabled = !is_busy && self.selected_mp4.is_some() && self.selected_csv.is_some();
+            if ui.add_enabled(train_enabled, button(train_label, purple, train_enabled)).clicked() {
                 process.call_platform_action("run_train");
                 self.telemetry_running = true;
             }
@@ -186,10 +200,10 @@ impl ScenePanel {
         if !cfg!(target_os = "android") {
             ui.add_space(4.0);
             ui.horizontal(|ui| {
-                if ui.add(button("📂 Directory", blue)).clicked() {
+                if ui.add_enabled(!is_busy, button("📂 Directory", blue, !is_busy)).clicked() {
                     load_option = Some(DataSource::PickDirectory);
                 }
-                if ui.add(button("🔗 URL", blue)).clicked() {
+                if ui.add_enabled(!is_busy, button("🔗 URL", blue, !is_busy)).clicked() {
                     self.show_url_dialog = true;
                 }
             });
@@ -199,7 +213,7 @@ impl ScenePanel {
     }
 
 
-    fn draw_url_dialog(&mut self, ui: &egui::Ui) -> Option<DataSource> {
+    fn draw_url_dialog(&mut self, ui: &egui::Ui, is_busy: bool) -> Option<DataSource> {
         let mut load_option = None;
 
         if self.show_url_dialog {
@@ -222,7 +236,8 @@ impl ScenePanel {
                         ui.add_space(10.0);
 
                         ui.horizontal(|ui| {
-                            if ui.button("Load").clicked() && !self.url.trim().is_empty() {
+                            let is_valid = !self.url.trim().is_empty() && !is_busy;
+                            if ui.add_enabled(is_valid, egui::Button::new("Load")).clicked() {
                                 load_option = Some(DataSource::Url(self.url.clone()));
                                 self.show_url_dialog = false;
                             }
@@ -234,6 +249,7 @@ impl ScenePanel {
                         if url_response.lost_focus()
                             && ui.input(|i| i.key_pressed(egui::Key::Enter))
                             && !self.url.trim().is_empty()
+                            && !is_busy
                         {
                             load_option = Some(DataSource::Url(self.url.clone()));
                             self.show_url_dialog = false;
@@ -547,13 +563,15 @@ impl ScenePanel {
                     data,
                 } => {
                     match event_type.as_str() {
-                        "extraction_complete" => {
+                        "extraction_complete" | "extraction_failed" => {
                             self.is_extracting = false;
                         }
-                        "telemetry_complete" => {
+                        "telemetry_complete" | "telemetry_failed" => {
                             self.telemetry_running = false;
-                            // Automatically load the resulting PLY
-                            self.start_loading(DataSource::Path(data), process);
+                            if event_type.as_str() == "telemetry_complete" {
+                                // Automatically load the resulting PLY
+                                self.start_loading(DataSource::Path(data), process);
+                            }
                         }
                         _ => {}
                     }
@@ -612,7 +630,10 @@ impl AppPane for ScenePanel {
             .min_size(egui::vec2(50.0, 18.0));
 
             if ui
-                .add(new_button)
+                .add_enabled(
+                    !self.is_extracting && !self.telemetry_running,
+                    new_button,
+                )
                 .on_hover_text("Start over with a new file")
                 .clicked()
             {
@@ -948,8 +969,9 @@ impl AppPane for ScenePanel {
                 });
             });
 
+            let is_busy = self.is_extracting || self.telemetry_running;
             // Draw URL dialog if open
-            if let Some(source) = self.draw_url_dialog(ui) {
+            if let Some(source) = self.draw_url_dialog(ui, is_busy) {
                 self.start_loading(source, process);
             }
         } else {


### PR DESCRIPTION
### 1. Training Validation & Visual Feedback
* **Explicit Visual Dimming**: Updated the button helper block in `scene.rs` so disabled actions ("Train", "Extract", "Load") dynamically dim their explicit `.fill()` background colors, cleanly communicating when they cannot be clicked.
* **Strict "Train" Guardline**: The "Train" button execution requires rigorous fulfillment: It is entirely disabled unless both an MP4 and CSV are successfully chosen and there are no active background processes (`!is_busy`).
* **Extract Flexibility**: The "Extract" behavior in Android handles standard file picking natively inline, so the standalone "Extract" button no longer mandates a pre-selected MP4 to become enabled; it now only disables itself if another background operation is running.
* **Rust-Java Synchronization Flow**: Addressed an event-passing bug in Java. After extraction correctly caches the file path, `MainActivity.java` successfully fires `mp4_picked` back up to the Rust environment so that downstream processes like the "Train" button magically unlock.
* **Dynamic Web-URL Validation**: The "Load" button inside the URL dialog intelligently detects string lengths, dynamically enforcing its visual disabled state whenever the URL inputs are empty.

### 2. Edge Case & UI Deadlock Preventions (Latest Commits)
* **Android Native Picker UI Unlocking**: Corrected a deadlock where escaping or cancelling the native "Extract" file picker did not notify Rust. `extraction_failed` is now pushed through the platform channels, dropping Rust's `is_busy` flags automatically and preventing infinite UI hangs.
* **Native Process Exception Safety**: Rust is now explicitly notified (`telemetry_failed` or `extraction_failed`) if native operations like `VideoFrameExtractor` or `TelemetryPreprocessor` error out or throw exceptions. The UI safely recovers instead of spinning forever.
* **URL Dialog Keyboard Bypass Guard**: Added an explicit `is_busy` condition to the URL Enter-Key listener. This prevents users from initiating concurrent UI loads by pressing Enter on the keyboard if they somehow opened the dialog prior to starting extraction loops. 
* **Ghost "New" Button Lockdown**: The top-right "New" button in the scene header is now contextibly disabled while operations pull background memory (`!self.is_extracting && !self.telemetry_running`). This safely prevents users from resetting the global view session while Java operations are asynchronously streaming active outputs.