### PR TITLE
fixed the telemetry realignment and csv parser along with pre processing

### DIFF
--- a/crates/brush-app/app/src/main/java/com/splats/app/MainActivity.java
+++ b/crates/brush-app/app/src/main/java/com/splats/app/MainActivity.java
@@ -108,6 +108,10 @@ public class MainActivity extends GameActivity {
         });
     }
 
+    public static void runTelemetry() {
+        runTrain();
+    }
+
 
 
     // ── Instance fields ───────────────────────────────────────────────────────
@@ -375,12 +379,31 @@ public class MainActivity extends GameActivity {
         try {
             if (uri == null) return null;
 
-            String name = queryDisplayName(uri);
-            String ext = fallbackExt;
-            if (name != null && name.contains(".")) {
-                ext = name.substring(name.lastIndexOf('.'));
+            String originalName = queryDisplayName(uri);
+            if (originalName == null || originalName.trim().isEmpty()) {
+                String lastSegment = uri.getLastPathSegment();
+                if (lastSegment != null && !lastSegment.trim().isEmpty()) {
+                    originalName = lastSegment;
+                }
             }
-            File out = new File(getCacheDir(), prefix + System.currentTimeMillis() + ext);
+
+            String ext = fallbackExt;
+            if (originalName != null && originalName.contains(".")) {
+                ext = originalName.substring(originalName.lastIndexOf('.'));
+            }
+
+            String safeName = (originalName != null) ? originalName.replaceAll("[^a-zA-Z0-9.\\-_]", "_") : System.currentTimeMillis() + ext;
+            File out = new File(getCacheDir(), safeName);
+            if (out.exists()) {
+                String baseName = stripExtension(safeName);
+                String fileExt = safeName.contains(".")
+                        ? safeName.substring(safeName.lastIndexOf('.'))
+                        : ext;
+                out = new File(
+                        getCacheDir(),
+                        prefix + baseName + "_" + System.currentTimeMillis() + fileExt
+                );
+            }
 
             try (InputStream in = getContentResolver().openInputStream(uri);
                  OutputStream outStream = new FileOutputStream(out)) {

--- a/crates/brush-app/app/src/main/java/com/splats/app/VideoFrameExtractor.java
+++ b/crates/brush-app/app/src/main/java/com/splats/app/VideoFrameExtractor.java
@@ -74,6 +74,7 @@ public class VideoFrameExtractor {
             try {
                 MediaMetadataRetriever retriever = new MediaMetadataRetriever();
                 retriever.setDataSource(context, videoUri);
+                Log.i(TAG, "Starting frame extraction for " + videoUri);
 
                 String durationStr = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION);
                 long durationMs = 0;
@@ -94,17 +95,24 @@ public class VideoFrameExtractor {
                             single.compress(Bitmap.CompressFormat.JPEG, 95, fos);
                         }
                         single.recycle();
+                        Log.i(TAG, "Duration metadata missing; wrote fallback frame to " + f.getAbsolutePath());
                     }
                     retriever.release();
+                    File outDir = context.getExternalFilesDir(Environment.DIRECTORY_PICTURES);
+                    Log.i(TAG, "Extraction complete: wrote " + countExtractedFrames(outDir)
+                            + " frame(s) to " + (outDir != null ? outDir.getAbsolutePath() : "<null>"));
                     finishExtraction(context, dialogHolder[0], callback, "Extraction complete (1 frame)");
                     return;
                 }
 
                 long durationUs = durationMs * 1000L;
                 long stepUs = durationUs / FRAME_COUNT;
+                Log.i(TAG, "Video durationMs=" + durationMs + ", durationUs=" + durationUs
+                        + ", targetFrames=" + FRAME_COUNT + ", stepUs=" + stepUs);
 
                 File outputDir = context.getExternalFilesDir(Environment.DIRECTORY_PICTURES);
                 if (outputDir != null && !outputDir.exists()) outputDir.mkdirs();
+                int writtenFrames = 0;
 
                 for (int i = 0; i < FRAME_COUNT; i++) {
                     long timeUs = i * stepUs;
@@ -143,6 +151,7 @@ public class VideoFrameExtractor {
                         try (FileOutputStream fos = new FileOutputStream(outFile)) {
                             bitmap.compress(Bitmap.CompressFormat.JPEG, 95, fos);
                             fos.flush();
+                            writtenFrames++;
                         } catch (Exception e) {
                             Log.e(TAG, "Failed to write frame file " + outFile, e);
                         } finally {
@@ -158,6 +167,9 @@ public class VideoFrameExtractor {
                 }
 
                 retriever.release();
+                Log.i(TAG, "Extraction finished: wrote " + writtenFrames + "/" + FRAME_COUNT
+                        + " frame(s), filesOnDisk=" + countExtractedFrames(outputDir)
+                        + ", outputDir=" + (outputDir != null ? outputDir.getAbsolutePath() : "<null>"));
                 finishExtraction(context, dialogHolder[0], callback, "Extraction finished");
 
             } catch (Exception e) {
@@ -221,5 +233,11 @@ public class VideoFrameExtractor {
         if (!file.delete()) {
             Log.w(TAG, "Failed to delete stale file: " + file.getAbsolutePath());
         }
+    }
+
+    private static int countExtractedFrames(File dir) {
+        if (dir == null || !dir.exists() || !dir.isDirectory()) return 0;
+        File[] files = dir.listFiles((ignored, name) -> name.startsWith("frame_") && name.endsWith(".jpg"));
+        return files != null ? files.length : 0;
     }
 }

--- a/crates/brush-app/app/src/main/java/com/splats/app/sfm/TelemetrySparseReconstruction.java
+++ b/crates/brush-app/app/src/main/java/com/splats/app/sfm/TelemetrySparseReconstruction.java
@@ -36,10 +36,27 @@ public final class TelemetrySparseReconstruction {
             throw new IllegalStateException("Extracted frames directory is missing");
         }
 
+        int filesOnDisk = countExtractedFrames(framesDir);
+        Log.i(TAG, "Preparing sparse reconstruction with "
+                + sequence.getRecords().size() + " pose record(s), "
+                + filesOnDisk + " extracted frame file(s) in " + framesDir.getAbsolutePath());
+
         VideoIntrinsics intrinsics = estimateIntrinsics(sequence.getVideoPath());
-        List<FrameData> frames = loadFramesForSequence(sequence, framesDir);
+        FrameLoadSummary frameSummary = loadFramesForSequence(sequence, framesDir);
+        List<FrameData> frames = frameSummary.frames;
+        Log.i(TAG, "Matched " + frames.size() + "/" + frameSummary.expectedCount
+                + " pose frame(s) to extracted images");
+        if (!frameSummary.missingFrameNames.isEmpty()) {
+            Log.w(TAG, "Missing extracted frame files (sample): " + frameSummary.missingFrameNames);
+        }
         if (frames.size() < 2) {
-            throw new IllegalStateException("Could not load enough extracted frames");
+            throw new IllegalStateException(
+                    "Could not load enough extracted frames. matched=" + frames.size()
+                            + ", expected=" + frameSummary.expectedCount
+                            + ", filesOnDisk=" + filesOnDisk
+                            + ", dir=" + framesDir.getAbsolutePath()
+                            + ", missingSample=" + frameSummary.missingFrameNames
+            );
         }
 
         JSONArray gps = new JSONArray();
@@ -95,16 +112,20 @@ public final class TelemetrySparseReconstruction {
     }
 
 
-    private static List<FrameData> loadFramesForSequence(PoseStampSequence sequence, File framesDir) {
+    private static FrameLoadSummary loadFramesForSequence(PoseStampSequence sequence, File framesDir) {
         List<FrameData> frames = new ArrayList<>();
+        List<String> missing = new ArrayList<>();
         for (PoseStamp record : sequence.getRecords()) {
             File frameFile = new File(framesDir, String.format("frame_%03d.jpg", record.getFrameIndex()));
             if (!frameFile.exists()) {
+                if (missing.size() < 12) {
+                    missing.add(frameFile.getName());
+                }
                 continue;
             }
             frames.add(new FrameData(frames.size(), record, frameFile, buildCameraPose(record)));
         }
-        return frames;
+        return new FrameLoadSummary(frames, sequence.getRecords().size(), missing);
     }
 
 
@@ -351,6 +372,18 @@ public final class TelemetrySparseReconstruction {
         }
     }
 
+    private static final class FrameLoadSummary {
+        final List<FrameData> frames;
+        final int expectedCount;
+        final List<String> missingFrameNames;
+
+        FrameLoadSummary(List<FrameData> frames, int expectedCount, List<String> missingFrameNames) {
+            this.frames = frames;
+            this.expectedCount = expectedCount;
+            this.missingFrameNames = missingFrameNames;
+        }
+    }
+
     private static final class CameraPose {
         final double[][] rotationWorldToCamera;
         final double[] translation;
@@ -378,5 +411,13 @@ public final class TelemetrySparseReconstruction {
             this.cx = cx;
             this.cy = cy;
         }
+    }
+
+    private static int countExtractedFrames(File dir) {
+        if (dir == null || !dir.exists() || !dir.isDirectory()) {
+            return 0;
+        }
+        File[] files = dir.listFiles((ignored, name) -> name.startsWith("frame_") && name.endsWith(".jpg"));
+        return files != null ? files.length : 0;
     }
 }

--- a/crates/brush-app/app/src/main/java/com/splats/app/telemetry/CsvIngestParser.kt
+++ b/crates/brush-app/app/src/main/java/com/splats/app/telemetry/CsvIngestParser.kt
@@ -8,64 +8,23 @@ import android.util.Log
 
 // ─── Column name mapping ──────────────────────────────────────────────────────
 
-/**
- * Maps canonical field names to the two known vendor header variants.
- * DJI aliases are checked only on the DJI pass.
- * Litchi aliases are checked only on the Litchi pass.
- */
 private data class HeaderAliases(
-    val dji: List<String>,
-    val litchi: List<String> = emptyList()
+    val aliases: List<String>
 )
 
 private object ColumnMap {
-    val TIMESTAMP    = HeaderAliases(
-        dji = listOf("time(millisecond)", "timestamps_ns"),
-        litchi = listOf("datetime(utc)")
-    )
-    val LAT          = HeaderAliases(
-        dji = listOf("latitude", "osd.latitude"),
-        litchi = listOf("gps(0)[latitude]")
-    )
-    val LON          = HeaderAliases(
-        dji = listOf("longitude", "osd.longitude"),
-        litchi = listOf("gps(0)[longitude]")
-    )
-    val ALT          = HeaderAliases(
-        dji = listOf("altitude(m)", "osd.altitude[ft]", "osd.height[ft]", "altitude_ft"),
-        litchi = listOf("altitude(m)")
-    )
-    val HEADING      = HeaderAliases(
-        dji = listOf("compass_heading(degrees)", "yaw"),
-        litchi = listOf("yaw(deg)")
-    )
-    val GIMBAL_PITCH = HeaderAliases(
-        dji = listOf("gimbal_pitch(degrees)", "gimbal.pitch", "gimbal_pitch"),
-        litchi = listOf("gimbalpitchraw")
-    )
-    val VEL_N        = HeaderAliases(
-        dji = listOf("speed_n(m/s)", "osd.yspeed[mph]"),
-        litchi = listOf("velocityy(mps)")
-    )
-    val VEL_E        = HeaderAliases(
-        dji = listOf("speed_e(m/s)", "osd.xspeed[mph]"),
-        litchi = listOf("velocityx(mps)")
-    )
-    val VEL_D        = HeaderAliases(
-        dji = listOf("speed_d(m/s)", "osd.zspeed[mph]", "vertical_speed_mph"),
-        litchi = listOf("velocityz(mps)")
-    )
-    val HDOP         = HeaderAliases(
-        dji = listOf("gps(accuracy)", "osd.gpslevel", "osd.gpsnum", "satellites")
-    )
-    val FIX_TYPE     = HeaderAliases(
-        dji = listOf("gps(fixType)", "osd.gpslevel"),
-        litchi = listOf("fixType")
-    )
-    val SATELLITES   = HeaderAliases(
-        dji = listOf("satellites", "osd.gpsnum"),
-        litchi = listOf("satellites")
-    )
+    val TIMESTAMP    = HeaderAliases(listOf("datetime(utc)"))
+    val LAT          = HeaderAliases(listOf("latitude"))
+    val LON          = HeaderAliases(listOf("longitude"))
+    val ALT          = HeaderAliases(listOf("altitude(m)"))
+    val HEADING      = HeaderAliases(listOf("yaw(deg)"))
+    val GIMBAL_PITCH = HeaderAliases(listOf("gimbalpitchraw"))
+    val VEL_N        = HeaderAliases(listOf("velocityy(mps)"))
+    val VEL_E        = HeaderAliases(listOf("velocityx(mps)"))
+    val VEL_D        = HeaderAliases(listOf("velocityz(mps)"))
+    val HDOP         = HeaderAliases(emptyList()) // Not usually in Litchi
+    val FIX_TYPE     = HeaderAliases(listOf("fixType"))
+    val SATELLITES   = HeaderAliases(listOf("satellites"))
 }
 
 // ─── CSV Ingest ───────────────────────────────────────────────────────────────
@@ -169,53 +128,71 @@ internal object CsvIngest {
 /**
  * Stage 2 — Type-safe parsing.
  *
- * Resolves header names to column indices (DJI first, Litchi second).
+ * Resolves Litchi header names to column indices.
  * Coerces raw strings into typed [TelRow] instances.
  * Litchi "datetime(utc)" strings are converted to microseconds since epoch.
  */
 internal object CsvParser {
     private const val TAG = "TelemetryCsv"
+    private val filenameDateTimeRegex = Regex("""(\d{4}-\d{2}-\d{2})[ _](\d{2})[:_-](\d{2})[:_-](\d{2})""")
+    private val filenameTimeRegex = Regex("""(?<!\d)(\d{2})[:_-](\d{2})[:_-](\d{2})(?!\d)""")
 
-    /**
-     * Attempt DJI column map first, then Litchi.
-     * If both fail, raises [TelemetryError.InsufficientRecords].
-     * Returns (rows, vendorWarning) — vendorWarning is true if the second
-     * (Litchi) pass was needed, so the caller can record it in the report.
-     */
     fun parse(
         headers: List<String>,
-        dataRows: List<List<String>>
-    ): Pair<List<TelRow>, Boolean> {
+        dataRows: List<List<String>>,
+        targetStartUs: Long = 0L
+    ): List<TelRow> {
         Log.i(TAG, "Parse headers raw: ${headers.joinToString("|")}")
         Log.i(TAG, "Parse headers norm: ${headers.map { normalizeHeader(it) }.joinToString("|")}")
-        // First pass: DJI
         return try {
-            val rows = parseWithMap(headers, dataRows, vendorIndex = 0)
-            Pair(rows, false)
-        } catch (e: TelemetryError.InsufficientRecords) {
-            // Second pass: Litchi (spec §6.2 — Litchi vs DJI header mismatch)
-            try {
-                val rows = parseWithMap(headers, dataRows, vendorIndex = 1)
-                Pair(rows, true)   // vendorWarning = true
-            } catch (e2: TelemetryError.InsufficientRecords) {
-                throw TelemetryError.InsufficientRecords(0)
+            val rows = parseInternal(headers, dataRows)
+            if (targetStartUs > 0) {
+                Log.i(TAG, "Filtering CSV to start at time $targetStartUs")
+                rows.filter { it.timestampUs >= targetStartUs }
+            } else {
+                rows
             }
+        } catch (e: TelemetryError.InsufficientRecords) {
+            throw TelemetryError.InsufficientRecords(0)
         }
     }
 
-    /**
-     * Internal parse using vendor index 0 = DJI, 1 = Litchi.
-     */
-    private fun parseWithMap(
+    fun parseStartTimeFromFilename(filename: String, rows: List<TelRow>): Long {
+        val dateTimeMatch = filenameDateTimeRegex.find(filename)
+        if (dateTimeMatch != null) {
+            val (date, hr, min, sec) = dateTimeMatch.destructured
+            val sdf = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.US)
+            sdf.timeZone = TimeZone.getTimeZone("UTC")
+            return try {
+                sdf.parse("$date $hr:$min:$sec")?.time?.times(1_000L) ?: 0L
+            } catch (e: Exception) {
+                0L
+            }
+        }
+
+        val baseDateUs = rows.firstOrNull { it.timestampUs > 0L }?.timestampUs ?: return 0L
+        val timeMatch = filenameTimeRegex.find(filename) ?: return 0L
+        val (hr, min, sec) = timeMatch.destructured
+        val sdf = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.US)
+        sdf.timeZone = TimeZone.getTimeZone("UTC")
+        return try {
+            val dayStartUs = (baseDateUs / 86_400_000_000L) * 86_400_000_000L
+            val dayStart = sdf.format(java.util.Date(dayStartUs / 1_000L))
+                .substring(0, 10)
+            sdf.parse("$dayStart $hr:$min:$sec")?.time?.times(1_000L) ?: 0L
+        } catch (e: Exception) {
+            0L
+        }
+    }
+
+    private fun parseInternal(
         headers: List<String>,
-        dataRows: List<List<String>>,
-        vendorIndex: Int
+        dataRows: List<List<String>>
     ): List<TelRow> {
         val lower = headers.map { normalizeHeader(it) }
 
-        fun resolve(aliases: HeaderAliases): Int? {
-            val candidates = if (vendorIndex == 0) aliases.dji else aliases.litchi
-            for (alias in candidates) {
+        fun resolve(headerAliases: HeaderAliases): Int? {
+            for (alias in headerAliases.aliases) {
                 val idx = lower.indexOf(normalizeHeader(alias))
                 if (idx >= 0) return idx
             }
@@ -232,24 +209,20 @@ internal object CsvParser {
         val iVelN       = resolve(ColumnMap.VEL_N)      ?: throw TelemetryError.InsufficientRecords(0)
         val iVelE       = resolve(ColumnMap.VEL_E)      ?: throw TelemetryError.InsufficientRecords(0)
         val iVelD       = resolve(ColumnMap.VEL_D)      ?: throw TelemetryError.InsufficientRecords(0)
-        val iHdop       = resolve(ColumnMap.HDOP)       ?: throw TelemetryError.InsufficientRecords(0)
+        val iHdop       = resolve(ColumnMap.HDOP)
         val iFixType    = resolve(ColumnMap.FIX_TYPE)
         val iSatellites = resolve(ColumnMap.SATELLITES)
 
-        val tsHeader = lower[iTs]
         val altHeader = lower[iAlt]
         val velNHeader = lower[iVelN]
         val velEHeader = lower[iVelE]
         val velDHeader = lower[iVelD]
-        val hdopHeader = lower[iHdop]
+        val hdopHeader = iHdop?.let { lower[it] }
         val fixTypeHeader = iFixType?.let { lower[it] }
-
-        // Detect whether we're reading a Litchi file (datetime vs DJI timestamps).
-        val isLitchi = tsHeader.contains("datetime")
 
         return dataRows.mapNotNull { cols ->
             runCatching {
-                val tsUs = parseTimestampUs(cols.getOrElse(iTs) { "" }, tsHeader, isLitchi)
+                val tsUs = parseLitchiDateTime(cols.getOrElse(iTs) { "" })
                 TelRow(
                     timestampUs = tsUs,
                     lat         = cols.getOrElse(iLat)     { "0" }.toDouble(),
@@ -260,23 +233,17 @@ internal object CsvParser {
                     velN        = parseSpeedMps(cols.getOrElse(iVelN) { "0" }, velNHeader),
                     velE        = parseSpeedMps(cols.getOrElse(iVelE) { "0" }, velEHeader),
                     velD        = parseSpeedMps(cols.getOrElse(iVelD) { "0" }, velDHeader),
-                    hdop        = parseHdop(cols.getOrElse(iHdop) { "0" }, hdopHeader),
+                    hdop        = iHdop?.let {
+                        parseHdop(cols.getOrElse(it) { "0" }, hdopHeader ?: "")
+                    } ?: 1.0,
                     fixType     = iFixType?.let {
                         parseFixType(cols.getOrElse(it) { "0" }, fixTypeHeader ?: "")
                     } ?: 3,
-                    satellites  = iSatellites?.let { cols.getOrElse(it) { "0" }.toInt() } ?: 0
+                    satellites  = iSatellites?.let {
+                        cols.getOrElse(it) { "0" }.toIntOrNull() ?: 0
+                    } ?: 0
                 )
             }.getOrNull()   // malformed rows are dropped; row validator counts them
-        }
-    }
-
-    private fun parseTimestampUs(raw: String, header: String, isLitchi: Boolean): Long {
-        if (isLitchi) return parseLitchiDateTime(raw)
-        val value = raw.toDoubleOrNull() ?: return 0L
-        return when {
-            header.contains("timestamps_ns") -> (value / 1_000.0).toLong()
-            header.contains("time(millisecond)") -> (value * 1_000.0).toLong()
-            else -> (value * 1_000.0).toLong()
         }
     }
 
@@ -343,8 +310,6 @@ internal object CsvParser {
 private fun looksLikeHeaderCells(cells: List<String>): Boolean {
     val norm = cells.map { normalizeHeader(it) }
     return norm.any { it.contains("latitude") }
-        || norm.any { it.contains("gps(0)[latitude]") }
-        || norm.any { it.contains("time(millisecond)") }
         || norm.any { it.contains("datetime(utc)") }
 }
 

--- a/crates/brush-app/app/src/main/java/com/splats/app/telemetry/TelemetryPreprocessor.kt
+++ b/crates/brush-app/app/src/main/java/com/splats/app/telemetry/TelemetryPreprocessor.kt
@@ -4,6 +4,9 @@ import android.media.MediaMetadataRetriever
 import android.util.Log
 import kotlinx.coroutines.*
 import java.io.File
+import java.text.SimpleDateFormat
+import java.util.Locale
+import java.util.TimeZone
 import kotlin.math.*
 import kotlin.jvm.JvmOverloads
 
@@ -95,11 +98,22 @@ class TelemetryPreprocessor @JvmOverloads constructor(
             if (!csvFile.exists())   throw TelemetryError.CsvNotFound(csvFile.absolutePath)
             if (!videoFile.exists()) throw TelemetryError.VideoNotFound(videoFile.absolutePath)
 
-            // Stage 1–2: Ingest + two-pass parse (DJI first, Litchi fallback)
+            // Stage 1–2: Ingest + single-pass parsing (strictly Litchi)
             reportProgress(ProcessingStage.PARSING, 0.0f)
-            val (headers, dataRows)    = CsvIngest.read(csvFile)
-            val (rawRows, vendorWarn)  = CsvParser.parse(headers, dataRows)
-            if (vendorWarn) warnings += "Column headers matched Litchi format (not DJI standard)."
+            val (headers, dataRows) = CsvIngest.read(csvFile)
+            val parsedRows = CsvParser.parse(headers, dataRows)
+            val targetStartUs = extractVideoStartUs(videoFile)
+                ?: CsvParser.parseStartTimeFromFilename(videoFile.name, parsedRows)
+            if (targetStartUs > 0L) {
+                Log.i(logTag, "Using telemetry start time ${targetStartUs}us for ${videoFile.name}")
+            } else {
+                Log.w(logTag, "Could not derive video start time from metadata or filename for ${videoFile.name}")
+            }
+            val rawRows = if (targetStartUs > 0L) {
+                parsedRows.filter { it.timestampUs >= targetStartUs }
+            } else {
+                parsedRows
+            }
             reportProgress(ProcessingStage.PARSING, 1.0f)
 
             // Stage 3: Row validation
@@ -128,10 +142,10 @@ class TelemetryPreprocessor @JvmOverloads constructor(
                 LongArray(cands.size) { cands[it].timestampUs }
             }
 
-            // Stage 6: Time sync
+            // Stage 6: Time sync bypassing (alignment already guaranteed via filename clipping)
             reportProgress(ProcessingStage.SYNCING, 0.0f)
-            val sync = TimeSyncEngine.sync(imuRecords, videoFile)
-            val alignedRecords = imuRecords.map { it.copy(tsAligned = it.timestampUs + sync.offsetUs) }
+            val syncOffsetUs = 0L
+            val alignedRecords = imuRecords.map { it.copy(tsAligned = it.timestampUs + syncOffsetUs) }
             reportProgress(ProcessingStage.SYNCING, 1.0f)
 
             // Stage 7: Interpolation
@@ -155,7 +169,7 @@ class TelemetryPreprocessor @JvmOverloads constructor(
             reportProgress(ProcessingStage.EMITTING, 0.0f)
             val sequence = PoseStampSequence(
                 origin = origin,
-                timeOffsetUs = sync.offsetUs,
+                timeOffsetUs = syncOffsetUs,
                 records = qResult.retained.sortedBy { it.ptsUs },
                 sourceMode = TelemetryMode.MODE_C,
                 logPath = csvFile,
@@ -172,8 +186,8 @@ class TelemetryPreprocessor @JvmOverloads constructor(
                 outputFrames = qResult.retained.size,
                 excludedFrames = qResult.excluded.size,
                 flaggedFrames = qResult.retained.count { it.flags != QualityFlag.CLEAN },
-                syncOffsetMs = sync.offsetUs / 1_000.0,
-                syncCorrelation = sync.correlation,
+                syncOffsetMs = syncOffsetUs / 1_000.0,
+                syncCorrelation = 1.0,
                 origin = origin,
                 processingTimeMs = System.currentTimeMillis() - startMs,
                 warnings = warnings
@@ -213,6 +227,51 @@ class TelemetryPreprocessor @JvmOverloads constructor(
 
     private suspend fun reportProgress(stage: ProcessingStage, fraction: Float) {
         withContext(Dispatchers.Main) { callback.onProgress(stage, fraction) }
+    }
+
+    private fun extractVideoStartUs(videoFile: File): Long? {
+        var retriever: MediaMetadataRetriever? = null
+        return try {
+            retriever = MediaMetadataRetriever()
+            retriever.setDataSource(videoFile.absolutePath)
+            val rawDate = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DATE)
+            val parsed = parseVideoCreationTimeUs(rawDate)
+            if (parsed != null) {
+                Log.i(logTag, "Video metadata start time for ${videoFile.name}: $rawDate")
+            }
+            parsed
+        } catch (e: Exception) {
+            Log.w(logTag, "Failed to read video metadata date for ${videoFile.name}", e)
+            null
+        } finally {
+            runCatching { retriever?.release() }
+        }
+    }
+
+    private fun parseVideoCreationTimeUs(rawDate: String?): Long? {
+        if (rawDate.isNullOrBlank()) return null
+        val normalized = rawDate.trim()
+
+        val patterns = listOf(
+            "yyyy-MM-dd'T'HH:mm:ss.SSSSSS'Z'",
+            "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'",
+            "yyyy-MM-dd'T'HH:mm:ss'Z'",
+            "yyyyMMdd'T'HHmmss.SSS'Z'",
+            "yyyyMMdd'T'HHmmss'Z'",
+            "yyyyMMdd'T'HHmmssZ",
+            "yyyy-MM-dd HH:mm:ss"
+        )
+
+        for (pattern in patterns) {
+            val sdf = SimpleDateFormat(pattern, Locale.US)
+            sdf.timeZone = TimeZone.getTimeZone("UTC")
+            val parsed = runCatching { sdf.parse(normalized) }.getOrNull()
+            if (parsed != null) {
+                return parsed.time * 1_000L
+            }
+        }
+
+        return null
     }
 }
 

--- a/crates/brush-app/src/android.rs
+++ b/crates/brush-app/src/android.rs
@@ -63,14 +63,34 @@ pub unsafe extern "system" fn Java_com_splats_app_MainActivity_notifyPlatformEve
 
 #[cfg(target_os = "android")]
 fn call_java_static(method: &str) {
-    let vm = rrfd::android::get_jvm().expect("JVM not initialized");
-    let mut env = vm.attach_current_thread().unwrap();
+    let vm = match rrfd::android::get_jvm() {
+        Some(vm) => vm,
+        None => {
+            log::error!("JVM not initialized when calling MainActivity.{method}()");
+            return;
+        }
+    };
+    let mut env = match vm.attach_current_thread() {
+        Ok(env) => env,
+        Err(err) => {
+            log::error!("Failed to attach JNI thread for MainActivity.{method}(): {err:?}");
+            return;
+        }
+    };
 
     let class_ref = MAIN_ACTIVITY_CLASS.read().unwrap();
-    let class = class_ref.as_ref().expect("MainActivity class not cached");
+    let Some(class) = class_ref.as_ref() else {
+        log::error!("MainActivity class not cached when calling {method}()");
+        return;
+    };
 
-    env.call_static_method(class, method, "()V", &[])
-        .unwrap_or_else(|e| panic!("Failed to call {method}: {e:?}"));
+    if let Err(err) = env.call_static_method(class.as_obj(), method, "()V", &[]) {
+        log::error!("Failed to call MainActivity.{method}(): {err:?}");
+        if env.exception_check().unwrap_or(false) {
+            let _ = env.exception_describe();
+            let _ = env.exception_clear();
+        }
+    }
 }
 
 #[unsafe(no_mangle)]

--- a/crates/brush-ui/src/scene.rs
+++ b/crates/brush-ui/src/scene.rs
@@ -132,6 +132,29 @@ pub struct ScenePanel {
 }
 
 impl ScenePanel {
+    fn short_button_name(name: &str, max_chars: usize) -> String {
+        let char_count = name.chars().count();
+        if char_count <= max_chars {
+            return name.to_string();
+        }
+
+        let keep = max_chars.saturating_sub(3);
+        let prefix_len = keep / 2;
+        let suffix_len = keep.saturating_sub(prefix_len);
+
+        let prefix: String = name.chars().take(prefix_len).collect();
+        let suffix: String = name
+            .chars()
+            .rev()
+            .take(suffix_len)
+            .collect::<String>()
+            .chars()
+            .rev()
+            .collect();
+
+        format!("{prefix}...{suffix}")
+    }
+
     fn draw_load_buttons(&mut self, ui: &mut egui::Ui, process: &UiProcess) -> Option<DataSource> {
         let button_height = 28.0;
         let button_width = 100.0;
@@ -153,13 +176,13 @@ impl ScenePanel {
                 load_option = Some(DataSource::PickFile);
             }
             let mp4_label = self.selected_mp4.as_ref()
-                .map(|s| format!("🎬 {}", s))
+                .map(|s| format!("🎬 {}", Self::short_button_name(s, 18)))
                 .unwrap_or_else(|| "🎬 Choose MP4".to_string());
             if ui.add(button(&mp4_label, blue)).clicked() {
                 process.call_platform_action("choose_mp4");
             }
             let csv_label = self.selected_csv.as_ref()
-                .map(|s| format!("📄 {}", s))
+                .map(|s| format!("📄 {}", Self::short_button_name(s, 18)))
                 .unwrap_or_else(|| "📄 Choose CSV".to_string());
             if ui.add(button(&csv_label, green)).clicked() {
                 process.call_platform_action("choose_csv");

--- a/crates/brush-ui/src/ui_process.rs
+++ b/crates/brush-ui/src/ui_process.rs
@@ -326,7 +326,12 @@ impl UiProcess {
 
     pub fn call_platform_action(&self, name: &str) {
         if let Some(callback) = self.read().platform_actions.get(name) {
-            callback();
+            if let Err(err) = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| callback()))
+            {
+                log::error!("Platform action '{name}' panicked: {err:?}");
+            }
+        } else {
+            log::warn!("Platform action '{name}' is not registered");
         }
     }
 


### PR DESCRIPTION
1. Update MainActivity.java

Modify ensureLocalFileForUri to inject the original uploaded file name into the cached file rather than just appending System.currentTimeMillis().
 2. Update CsvIngestParser.kt

Remove all DJI-specific fields from ColumnMap and use only Litchi fields.
Remove Two-Pass Fallback Logic.
Add extraction logic for start time based on the filename regex, parsing YYYY-MM-DD HH:mm:ss. If date is not provided, maybe try to match HH:mm:ss using the first valid timestamp's date. Or use UTC parsing.
Trim parsed TelRow data where timestampUs < targetStartUs.
 3. Update TelemetryPreprocessor.kt

Pass the original mp4file.name to CsvParser.parse.
Bypass TimeSyncEngine.sync and just set offsetUs = 0 and align directly, because the time is synced manually derived from the filename.